### PR TITLE
Tls: add custom_ssl_context parameter

### DIFF
--- a/ldap3/core/tls.py
+++ b/ldap3/core/tls.py
@@ -1,3 +1,6 @@
+"""
+"""
+
 # Created on 2013.08.05
 #
 # Author: Giovanni Cannata
@@ -192,7 +195,16 @@ class Tls(object):
         """
         Adds TLS to the connection socket
         """
-        if use_ssl_context:
+        if self.custom_ssl_context is not None:
+            ssl_context = self.custom_ssl_context
+            if self.sni:
+                wrapped_socket = ssl_context.wrap_socket(connection.socket, server_side=False, do_handshake_on_connect=do_handshake, server_hostname=self.sni)
+            else:
+                wrapped_socket = ssl_context.wrap_socket(connection.socket, server_side=False, do_handshake_on_connect=do_handshake)
+            self.validate = ssl_context.
+            if log_enabled(NETWORK):
+                log(NETWORK, 'socket wrapped with SSL using custom SSLContext for <%s>', connection)            
+        elif use_ssl_context:
             if self.version is None:  # uses the default ssl context for reasonable security
                 ssl_context = create_default_context(purpose=Purpose.SERVER_AUTH,
                                                      cafile=self.ca_certs_file,

--- a/ldap3/core/tls.py
+++ b/ldap3/core/tls.py
@@ -87,6 +87,10 @@ class Tls(object):
                 if log_enabled(ERROR):
                     log(ERROR, 'cannot use custom_ssl_context, SSLContext not available')
                 raise LDAPSSLNotSupportedError('cannot use custom_ssl_context, SSLContext not available')
+            if not is instance(custom_ssl_context, ssl.SSLContext):
+                if log_enabled(ERROR):
+                    log(ERROR, 'custom_ssl_context must be an ssl.SSLContext object')
+                raise LDAPSSLNotSupportedError('custom_ssl_context must be an ssl.SSLContext object')
             if not (local_private_key_file is None and
                  local_certificate_file is None and
                  validate == ssl.CERT_NONE and

--- a/ldap3/core/tls.py
+++ b/ldap3/core/tls.py
@@ -1,6 +1,3 @@
-"""
-"""
-
 # Created on 2013.08.05
 #
 # Author: Giovanni Cannata
@@ -80,7 +77,29 @@ class Tls(object):
                  local_private_key_password=None,
                  ciphers=None,
                  sni=None,
-                 peer_certificate=None):
+                 peer_certificate=None,
+                 custom_ssl_context=None):
+        if custom_ssl_context is not None:
+            if not use_ssl_context:
+                if log_enabled(ERROR):
+                    log(ERROR, 'cannot use custom_ssl_context, SSLContext not available')
+                raise LDAPSSLNotSupportedError('cannot use custom_ssl_context, SSLContext not available')
+            if not (local_private_key_file is None and
+                 local_certificate_file is None and
+                 validate == ssl.CERT_NONE and
+                 version is None and
+                 ssl_options is None and
+                 ca_certs_file is None and
+                 valid_names is None and
+                 ca_certs_path is None and
+                 ca_certs_data is None and
+                 local_private_key_password is None and
+                 ciphers is None and
+                 peer_certificate is None):
+                 if log_enabled(ERROR):
+                     log(ERROR, 'cannot specify other parameters when using custom_ssl_context')
+                 raise LDAPSSLConfigurationError('cannot specify other parameters when using custom_ssl_context')
+        self.custom_ssl_context = custom_ssl_context     
         if ssl_options is None:
             ssl_options = []
         self.ssl_options = ssl_options

--- a/ldap3/core/tls.py
+++ b/ldap3/core/tls.py
@@ -201,7 +201,7 @@ class Tls(object):
                 wrapped_socket = ssl_context.wrap_socket(connection.socket, server_side=False, do_handshake_on_connect=do_handshake, server_hostname=self.sni)
             else:
                 wrapped_socket = ssl_context.wrap_socket(connection.socket, server_side=False, do_handshake_on_connect=do_handshake)
-            self.validate = ssl_context.
+            self.validate = ssl_context.verify_mode
             if log_enabled(NETWORK):
                 log(NETWORK, 'socket wrapped with SSL using custom SSLContext for <%s>', connection)            
         elif use_ssl_context:


### PR DESCRIPTION
Add a custom_ssl_context parameter to `Tls()` that makes it possible to pass a custom `ssl.SSLContext` object for the TLS connection, allowing configurations not supported in the current code, such as more recent options like [ssl.SSLContext.verify_flags](https://docs.python.org/3.11/library/ssl.html#ssl.SSLContext.verify_flags).

One use case is to enable [partial certificate chain verification](https://docs.python.org/3.11/library/ssl.html#ssl.VERIFY_X509_PARTIAL_CHAIN) for pinning certificates in situations where a root certificate is not available.